### PR TITLE
Use anonymous keyword arguments forwarding in Types.standard

### DIFF
--- a/lib/ruby_git_crypt/options/types.rb
+++ b/lib/ruby_git_crypt/options/types.rb
@@ -6,8 +6,8 @@ require_relative 'types/flag'
 module RubyGitCrypt
   module Options
     module Types
-      def self.standard(name, value, **opts)
-        Standard.new(name, value, **opts)
+      def self.standard(name, value, **)
+        Standard.new(name, value, **)
       end
 
       def self.flag(name, value)


### PR DESCRIPTION
Fixes two pre-existing `Style/ArgumentsForwarding` offences in `lib/ruby_git_crypt/options/types.rb` that make `rubocop` fail on main.

This lint failure is blocking the `check` job on the GHA migration PR #106.

`bundle exec rubocop` and `bundle exec rspec` (157 examples) both pass on this branch.